### PR TITLE
fix/2060 - Participant's Id was displayed as "Kf Id", now "Participant ID"

### DIFF
--- a/mappings/participant_centric.json
+++ b/mappings/participant_centric.json
@@ -4526,7 +4526,7 @@
           "displayValues": {},
           "quickSearchEnabled": false,
           "field": "kf_id",
-          "displayName": "Kf Id",
+          "displayName": "Participant ID",
           "active": false,
           "isArray": false,
           "rangeStep": null,


### PR DESCRIPTION
Fixes https://github.com/kids-first/kf-portal-ui/issues/2060